### PR TITLE
Refactor IRepository - Move TEntity from class to method

### DIFF
--- a/dotnet/Core.Data/AsyncRespository.cs
+++ b/dotnet/Core.Data/AsyncRespository.cs
@@ -9,34 +9,38 @@ using Microsoft.Extensions.Logging;
 
 namespace Platform8.Core.Data
 {
-  public class AsyncRepository<TContext, TEntity> : IAsyncRepository<TContext, TEntity>
-    where TEntity : class, IEntity
+  public class AsyncRepository<TContext> : IAsyncRepository<TContext>
     where TContext : DbContext
   {
 
     private ILogger logger;
 
-    public AsyncRepository(TContext context, ILogger<AsyncRepository<TContext, TEntity>> logger)
-    {
+    public AsyncRepository(TContext context, ILogger<AsyncRepository<TContext>> logger) {
+
       this.logger = logger;
       this.Context = context;
     }
 
     public DbContext Context { get; set; }
 
-    public async Task<TEntity> GetAsync(Guid id, CancellationToken cancellationToken = default)
-    {
+    public async Task<TEntity> GetAsync<TEntity>(Guid id, CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       return await this.Context.Set<TEntity>().FindAsync(id);
     }
 
-    public async Task<TEntity> FirstOrDefaultAsync(Expression<Func<TEntity, bool>> where, CancellationToken cancellationToken = default) {
+    public async Task<TEntity> FirstOrDefaultAsync<TEntity>(Expression<Func<TEntity, bool>> where, CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       return await FirstOrDefaultAsync(new QuerySpec<TEntity>
       {
         Where = where
       }, cancellationToken);
     }
 
-    public async Task<TEntity> FirstOrDefaultAsync<TProperty>(Expression<Func<TEntity, bool>> where, Expression<Func<TEntity, TProperty>> include, CancellationToken cancellationToken = default) {
+    public async Task<TEntity> FirstOrDefaultAsync<TEntity, TProperty>(Expression<Func<TEntity, bool>> where, Expression<Func<TEntity, TProperty>> include, CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       var querySpec = new QuerySpec<TEntity>
       {
         Where = where
@@ -46,28 +50,33 @@ namespace Platform8.Core.Data
       return await FirstOrDefaultAsync(querySpec, cancellationToken);
     }
 
-    public async Task<TEntity> FirstOrDefaultAsync(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default)
-    {
+    public async Task<TEntity> FirstOrDefaultAsync<TEntity>(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       return await spec.Apply(this.Context).FirstOrDefaultAsync(cancellationToken);
     }
 
-    public async Task<IReadOnlyList<TEntity>> ListAllAsync(CancellationToken cancellationToken = default)
-    {
+    public async Task<IReadOnlyList<TEntity>> ListAllAsync<TEntity>(CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       return await this.Context.Set<TEntity>().ToListAsync(cancellationToken);
     }
 
-    public Task<IReadOnlyList<TResult>> ListAsync<TResult>(IQuerySpec<TEntity, TResult> spec, CancellationToken cancellationToken = default)
-    {
+    public Task<IReadOnlyList<TResult>> ListAsync<TEntity, TResult>(IQuerySpec<TEntity, TResult> spec, CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       return Task.FromResult<IReadOnlyList<TResult>>(spec.Apply(this.Context).Select(spec.Selector).ToList());
     }
 
-    public async Task<IReadOnlyList<TEntity>> ListAsync(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default)
-    {
+    public async Task<IReadOnlyList<TEntity>> ListAsync<TEntity>(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default)
+      where TEntity: class, IEntity {
+
       return await spec.Apply(this.Context).ToListAsync(cancellationToken);
     }
 
-    public async Task<TEntity> SaveAsync(TEntity entity, CancellationToken cancellationToken)
-    {
+    public async Task<TEntity> SaveAsync<TEntity>(TEntity entity, CancellationToken cancellationToken)
+      where TEntity: class, IEntity {
+
       var savedEntity = this.Context.Add(entity);
       var result = await this.Context.SaveChangesAsync();
 

--- a/dotnet/Core.Data/IAsyncRepository.cs
+++ b/dotnet/Core.Data/IAsyncRepository.cs
@@ -7,17 +7,24 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Platform8.Core.Data
 {
-    public interface IAsyncRepository<TContext, TEntity>
-      where TEntity: IEntity
+    public interface IAsyncRepository<TContext>
       where TContext: DbContext
     {
-      Task<TEntity> GetAsync(Guid id, CancellationToken cancellationToken = default);
-      Task<TEntity> FirstOrDefaultAsync(Expression<Func<TEntity, bool>> where, CancellationToken cancellationToken = default);
-      Task<TEntity> FirstOrDefaultAsync<TProperty>(Expression<Func<TEntity, bool>> where, Expression<Func<TEntity, TProperty>> include, CancellationToken cancellationToken = default);
-      Task<TEntity> FirstOrDefaultAsync(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default);
-      Task<TEntity> SaveAsync(TEntity entity, CancellationToken cancellationToken = default);
-      Task<IReadOnlyList<TEntity>> ListAllAsync(CancellationToken cancellationToken = default);
-      Task<IReadOnlyList<TResult>> ListAsync<TResult>(IQuerySpec<TEntity, TResult> spec, CancellationToken cancellationToken = default);
-      Task<IReadOnlyList<TEntity>> ListAsync(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default);
+      Task<TEntity> GetAsync<TEntity>(Guid id, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<TEntity> FirstOrDefaultAsync<TEntity>(Expression<Func<TEntity, bool>> where, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<TEntity> FirstOrDefaultAsync<TEntity, TProperty>(Expression<Func<TEntity, bool>> where, Expression<Func<TEntity, TProperty>> include, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<TEntity> FirstOrDefaultAsync<TEntity>(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<TEntity> SaveAsync<TEntity>(TEntity entity, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<IReadOnlyList<TEntity>> ListAllAsync<TEntity>(CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<IReadOnlyList<TResult>> ListAsync<TEntity, TResult>(IQuerySpec<TEntity, TResult> spec, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
+      Task<IReadOnlyList<TEntity>> ListAsync<TEntity>(IQuerySpec<TEntity> spec, CancellationToken cancellationToken = default)
+        where TEntity: class, IEntity;
     }
 }

--- a/services/Accounts/Api/Startup.cs
+++ b/services/Accounts/Api/Startup.cs
@@ -63,7 +63,7 @@ namespace Platform8.Accounts.Api
         )
         .AddContinuousMigrations<AccountsDataContext>()
 
-        .AddScoped(typeof(IAsyncRepository<,>), typeof(AsyncRepository<,>))
+        .AddScoped(typeof(IAsyncRepository<>), typeof(AsyncRepository<>))
 
         .AddMediatR(Accounts.Commands.CommandsAssembly.Value);
 

--- a/services/Accounts/Commands/AddAccount.cs
+++ b/services/Accounts/Commands/AddAccount.cs
@@ -12,21 +12,18 @@ namespace Platform8.Accounts.Commands
 {
   public class AddAccountHandler : IRequestHandler<AddAccountRequest, AddAccountResponse>
   {
-    private readonly IAsyncRepository<AccountsDataContext, Models.Account> accounts;
-    private readonly IAsyncRepository<AccountsDataContext, Models.Balance> balances;
+    private readonly IAsyncRepository<AccountsDataContext> repository;
 
     public AddAccountHandler(
-      IAsyncRepository<AccountsDataContext, Models.Account> accounts,
-      IAsyncRepository<AccountsDataContext, Models.Balance> balances
+      IAsyncRepository<AccountsDataContext> repository
       )
     {
-      this.accounts = accounts;
-      this.balances = balances;
+      this.repository = repository;
     }
 
     public async Task<AddAccountResponse> Handle(AddAccountRequest request, CancellationToken cancellationToken)
     {
-      var account = await this.accounts.SaveAsync(new Models.Account
+      var account = await this.repository.SaveAsync(new Models.Account
       {
         OwnerId = request.OwnerId.Value,
         Name = request.Name,
@@ -36,7 +33,7 @@ namespace Platform8.Accounts.Commands
 
       if (request.StartingBalance.HasValue)
       {
-        var balance = await this.balances.SaveAsync(new Models.Balance
+        var balance = await this.repository.SaveAsync(new Models.Balance
         {
           Account = account,
           Amount = request.StartingBalance.Value

--- a/services/Accounts/Commands/ListAccounts.cs
+++ b/services/Accounts/Commands/ListAccounts.cs
@@ -12,9 +12,9 @@ namespace Platform8.Accounts.Commands
 {
   public class ListAccountsHandler : IRequestHandler<ListAccountsRequest, ListAccountsResponse>
   {
-    private readonly IAsyncRepository<AccountsDataContext, Models.Account> repository;
+    private readonly IAsyncRepository<AccountsDataContext> repository;
 
-    public ListAccountsHandler(IAsyncRepository<AccountsDataContext, Models.Account> repository)
+    public ListAccountsHandler(IAsyncRepository<AccountsDataContext> repository)
     {
       this.repository = repository;
     }
@@ -37,7 +37,7 @@ namespace Platform8.Accounts.Commands
 
       querySpec.AddInclude(a => a.Balances);
 
-      var list = await this.repository.ListAsync<AccountInList>(querySpec);
+      var list = await this.repository.ListAsync(querySpec);
 
       return new ListAccountsResponse(list);
     }

--- a/services/Accounts/Tests/Commands/AddAccount/Success.cs
+++ b/services/Accounts/Tests/Commands/AddAccount/Success.cs
@@ -47,7 +47,7 @@ namespace Platform8.Accounts.Tests
 
       var newAccountId = Guid.NewGuid();
 
-      Sut.SetupAsync<IAsyncRepository<AccountsDataContext, Models.Account>, Models.Account>(r => r.SaveAsync(Argument.IsAny<Models.Account>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<AccountsDataContext>, Models.Account>(r => r.SaveAsync(Argument.IsAny<Models.Account>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Models.Account {
           Id = newAccountId,
           Name = Request.Name,
@@ -58,7 +58,7 @@ namespace Platform8.Accounts.Tests
           Status = EntityStatus.Active
         });
 
-      Sut.SetupAsync<IAsyncRepository<AccountsDataContext, Models.Balance>, Models.Balance>(r => r.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<AccountsDataContext>, Models.Balance>(r => r.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Models.Balance {
           Id = Guid.NewGuid(),
           Account = Argument.Is<Account>(a => a.Id == newAccountId),
@@ -84,7 +84,7 @@ namespace Platform8.Accounts.Tests
     [Fact]
     public void It_should_save_a_new_Account_to_the_Data_Repository() => should_save_a_new_User_to_the_Data_Repository();
     It should_save_a_new_User_to_the_Data_Repository = () => {
-        Sut.Verify<IAsyncRepository<AccountsDataContext, Models.Account>>(p => p.SaveAsync(Argument.IsAny<Models.Account>(), Argument.IsAny<CancellationToken>()), Times.Once());
+        Sut.Verify<IAsyncRepository<AccountsDataContext>>(p => p.SaveAsync(Argument.IsAny<Models.Account>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 
     [Fact]
@@ -96,7 +96,7 @@ namespace Platform8.Accounts.Tests
     [Fact]
     public void It_should_save_a_new_Balance_to_the_Data_Repository() => should_save_a_new_Balance_to_the_Data_Repository();
     It should_save_a_new_Balance_to_the_Data_Repository = () => {
-      Sut.Verify<IAsyncRepository<AccountsDataContext, Models.Balance>>(p => p.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()), Times.Once());
+      Sut.Verify<IAsyncRepository<AccountsDataContext>>(p => p.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
   }
 }

--- a/services/Accounts/Tests/Commands/AddBalance/ExistingBalance.cs
+++ b/services/Accounts/Tests/Commands/AddBalance/ExistingBalance.cs
@@ -17,7 +17,6 @@ using Platform8.Accounts.Commands;
 using Platform8.Accounts.Models;
 using Platform8.Core.Data;
 using Platform8.Accounts.Data;
-using Platform8.Core;
 
 namespace Platform8.Accounts.Tests
 {
@@ -57,7 +56,7 @@ namespace Platform8.Accounts.Tests
         Date = DateTime.Parse("2021-02-15")
       };
 
-      Sut.SetupAsync<IAsyncRepository<AccountsDataContext, Models.Balance>, Models.Balance>(r =>
+      Sut.SetupAsync<IAsyncRepository<AccountsDataContext>, Models.Balance>(r =>
           r.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Models.Balance, bool>>>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(testBalance);
     };
@@ -77,14 +76,14 @@ namespace Platform8.Accounts.Tests
     public void It_should_not_save_the_Balance_to_the_Data_Repository() => should_not_save_the_Balance_to_the_Data_Repository();
     It should_not_save_the_Balance_to_the_Data_Repository = () =>
     {
-      Sut.Verify<IAsyncRepository<AccountsDataContext, Models.Balance>>(p => p.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()), Times.Never());
+      Sut.Verify<IAsyncRepository<AccountsDataContext>>(p => p.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()), Times.Never());
     };
 
     [Fact]
     public void It_should_get_an_existing_Balance_from_the_Data_Repository() => should_get_an_existing_Balance_from_the_Data_Repository();
     It should_get_an_existing_Balance_from_the_Data_Repository = () =>
     {
-      Sut.Verify<IAsyncRepository<AccountsDataContext, Models.Balance>>(p => p.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Models.Balance, bool>>>(), Argument.IsAny<CancellationToken>()), Times.Once());
+      Sut.Verify<IAsyncRepository<AccountsDataContext>>(p => p.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Models.Balance, bool>>>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 
     [Fact]

--- a/services/Accounts/Tests/Commands/AddBalance/Success.cs
+++ b/services/Accounts/Tests/Commands/AddBalance/Success.cs
@@ -55,10 +55,10 @@ namespace Platform8.Accounts.Tests
         Date = DateTime.Parse("2021-02-15")
       };
 
-      Sut.SetupAsync<IAsyncRepository<AccountsDataContext, Models.Account>, Models.Account>(r => r.GetAsync(Argument.Is<Guid>(x => x == testAccount.Id), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<AccountsDataContext>, Models.Account>(r => r.GetAsync<Models.Account>(Argument.Is<Guid>(x => x == testAccount.Id), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(testAccount);
 
-      Sut.SetupAsync<IAsyncRepository<AccountsDataContext, Models.Balance>, Models.Balance>(r => r.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<AccountsDataContext>, Models.Balance>(r => r.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Models.Balance
         {
           Id = Guid.NewGuid(),
@@ -85,7 +85,7 @@ namespace Platform8.Accounts.Tests
     public void It_should_save_a_new_Balance_to_the_Data_Repository() => should_save_a_new_Balance_to_the_Data_Repository();
     It should_save_a_new_Balance_to_the_Data_Repository = () =>
     {
-      Sut.Verify<IAsyncRepository<AccountsDataContext, Models.Balance>>(p => p.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()), Times.Once());
+      Sut.Verify<IAsyncRepository<AccountsDataContext>>(p => p.SaveAsync(Argument.IsAny<Models.Balance>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 
     [Fact]

--- a/services/Accounts/Tests/Commands/ListAccounts/Success.cs
+++ b/services/Accounts/Tests/Commands/ListAccounts/Success.cs
@@ -38,8 +38,8 @@ namespace Platform8.Accounts.Tests
     {
       Request = new ListAccountsRequest();
 
-      Sut.SetupAsync<IAsyncRepository<AccountsDataContext, Models.Account>, IReadOnlyList<Models.AccountInList>>(r
-        => r.ListAsync<AccountInList>(
+      Sut.SetupAsync<IAsyncRepository<AccountsDataContext>, IReadOnlyList<Models.AccountInList>>(r
+        => r.ListAsync<Models.Account, AccountInList>(
             Argument.IsAny<IQuerySpec<Models.Account, Models.AccountInList>>(),
             Argument.IsAny<CancellationToken>())
         )

--- a/services/Budgets/Api/Startup.cs
+++ b/services/Budgets/Api/Startup.cs
@@ -63,7 +63,7 @@ namespace Platform8.Budgets.Api
         )
         .AddContinuousMigrations<BudgetsDataContext>()
 
-        .AddScoped(typeof(IAsyncRepository<,>), typeof(AsyncRepository<,>))
+        .AddScoped(typeof(IAsyncRepository<>), typeof(AsyncRepository<>))
         .AddMediatR(Budgets.Commands.CommandsAssembly.Value)
         .AddAutoMapper(Budgets.Commands.CommandsAssembly.Value);
 

--- a/services/Budgets/Commands/AddCategory.cs
+++ b/services/Budgets/Commands/AddCategory.cs
@@ -15,34 +15,31 @@ namespace Platform8.Budgets.Commands
   public class AddCategoryHandler : IRequestHandler<AddCategoryRequest, AddCategoryResponse>
   {
     private readonly ILogger<AddCategoryHandler> logger;
-    private readonly IAsyncRepository<BudgetsDataContext, Data.Budget> budgets;
-    private readonly IAsyncRepository<BudgetsDataContext, Data.Category> categories;
+    private readonly IAsyncRepository<BudgetsDataContext> repository;
     private readonly IMapper mapper;
 
     public AddCategoryHandler(
       IMapper mapper,
       ILogger<AddCategoryHandler> logger,
-      IAsyncRepository<BudgetsDataContext, Data.Budget> budgets,
-      IAsyncRepository<BudgetsDataContext, Data.Category> categories
+      IAsyncRepository<BudgetsDataContext> repository
       )
     {
       this.mapper = mapper;
       this.logger = logger;
-      this.budgets = budgets;
-      this.categories = categories;
+      this.repository = repository;
     }
 
     public async Task<AddCategoryResponse> Handle(AddCategoryRequest request, CancellationToken cancellationToken)
     {
-      var budget = await this.budgets.FirstOrDefaultAsync(b => b.OwnerId == request.OwnerId);
+      var budget = await this.repository.FirstOrDefaultAsync<Data.Budget>(b => b.OwnerId == request.OwnerId);
 
       if (budget == null) {
-        budget = await this.budgets.SaveAsync(new Data.Budget {
+        budget = await this.repository.SaveAsync(new Data.Budget {
           OwnerId = request.OwnerId,
         });
       }
 
-      var category = await this.categories.SaveAsync(new Data.Category {
+      var category = await this.repository.SaveAsync(new Data.Category {
         Name = request.Name,
         Allocation = request.Allocation,
         Budget = budget

--- a/services/Budgets/Commands/FindCategoriesByName.cs
+++ b/services/Budgets/Commands/FindCategoriesByName.cs
@@ -12,12 +12,12 @@ namespace Platform8.Budgets.Commands
 {
   public class FindCategoriesByNameHandler : IRequestHandler<CategoryByNameRequest, CategoryByNameResponse>
   {
-    private readonly IAsyncRepository<BudgetsDataContext, Data.Category> categories;
+    private readonly IAsyncRepository<BudgetsDataContext> repository;
     private readonly IMapper mapper;
 
-    public FindCategoriesByNameHandler(IAsyncRepository<BudgetsDataContext, Data.Category> categories, IMapper mapper)
+    public FindCategoriesByNameHandler(IAsyncRepository<BudgetsDataContext> repository, IMapper mapper)
     {
-      this.categories = categories;
+      this.repository = repository;
       this.mapper = mapper;
     }
 
@@ -26,13 +26,13 @@ namespace Platform8.Budgets.Commands
       var querySpec = new QuerySpec<Data.Category, Models.Category>
       {
         Where = (c => c.Budget.OwnerId == request.OwnerId && c.Name.StartsWith(request.Name)),
-        OrderBy = (c => c.Name),       
+        OrderBy = (c => c.Name),
         Take = 10,
         Selector = c => this.mapper.Map<Models.Category>(c)
       };
       querySpec.AddInclude(c => c.Budget);
 
-      var list = await this.categories.ListAsync(querySpec);
+      var list = await this.repository.ListAsync(querySpec);
 
       return new CategoryByNameResponse {
         Categories = list

--- a/services/Budgets/Commands/GetBudget.cs
+++ b/services/Budgets/Commands/GetBudget.cs
@@ -1,13 +1,10 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using AutoMapper;
 using MediatR;
 
-using Platform8.Core;
 using Platform8.Core.Data;
 using Platform8.Budgets.Data;
 using Platform8.Budgets.Models;
@@ -16,18 +13,18 @@ namespace Platform8.Budgets.Commands
 {
   public class GetBudgetHandler : IRequestHandler<GetBudgetRequest, GetBudgetResponse>
   {
-    private readonly IAsyncRepository<BudgetsDataContext, Data.Budget> budgets;
+    private readonly IAsyncRepository<BudgetsDataContext> repository;
     private readonly IMapper mapper;
 
-    public GetBudgetHandler(IAsyncRepository<BudgetsDataContext, Data.Budget> budgets, IMapper mapper)
+    public GetBudgetHandler(IAsyncRepository<BudgetsDataContext> repository, IMapper mapper)
     {
-      this.budgets = budgets;
+      this.repository = repository;
       this.mapper = mapper;
     }
 
     public async Task<GetBudgetResponse> Handle(GetBudgetRequest request, CancellationToken cancellationToken)
     {
-      var budget = await this.budgets.FirstOrDefaultAsync(b => b.OwnerId == request.OwnerId, b => b.Categories);
+      var budget = await this.repository.FirstOrDefaultAsync<Data.Budget, IList<Data.Category>>(b => b.OwnerId == request.OwnerId, b => b.Categories);
 
       return new GetBudgetResponse {
         Budget = this.mapper.Map<Models.Budget>(budget)

--- a/services/Budgets/Tests/Commands/AddCategory/Success-With-No-Budget-Existing.cs
+++ b/services/Budgets/Tests/Commands/AddCategory/Success-With-No-Budget-Existing.cs
@@ -38,7 +38,7 @@ namespace Platform8.Budgets.Tests
 
     Establish context = () =>
     {
-    
+
       var testBudget = new Data.Budget
       {
         Id = Guid.NewGuid(),
@@ -56,15 +56,15 @@ namespace Platform8.Budgets.Tests
         }
       };
 
-      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext, Data.Budget>, Data.Budget>(r => r.SaveAsync(Argument.IsAny<Data.Budget>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext>, Data.Budget>(r => r.SaveAsync(Argument.IsAny<Data.Budget>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Data.Budget {
           Id = Guid.NewGuid(),
           OwnerId = TestUserId,
-          DateCreated = SystemTime.UtcNow,          
+          DateCreated = SystemTime.UtcNow,
           Status = EntityStatus.Active
         });
 
-      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext, Data.Category>, Data.Category>(r => r.SaveAsync(Argument.IsAny<Data.Category>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext>, Data.Category>(r => r.SaveAsync(Argument.IsAny<Data.Category>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Data.Category {
           Id = Guid.NewGuid(),
           Name = Request.Name,
@@ -89,13 +89,13 @@ namespace Platform8.Budgets.Tests
     public void It_should_try_to_get_the_Budget_the_user() => should_try_to_get_the_Budget_the_user();
     It should_try_to_get_the_Budget_the_user = () =>
     {
-      Sut.Verify<IAsyncRepository<BudgetsDataContext, Data.Budget>>(p => p.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Data.Budget, bool>>>(), Argument.IsAny<CancellationToken>()), Times.Once());
+      Sut.Verify<IAsyncRepository<BudgetsDataContext>>(p => p.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Data.Budget, bool>>>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 
     [Fact]
     public void It_should_save_a_new_Budget_to_the_Data_Repository() => should_save_a_new_Budget_to_the_Data_Repository();
     It should_save_a_new_Budget_to_the_Data_Repository = () => {
-        Sut.Verify<IAsyncRepository<BudgetsDataContext, Data.Budget>>(p => p.SaveAsync(Argument.Is<Data.Budget>(b => 
+        Sut.Verify<IAsyncRepository<BudgetsDataContext>>(p => p.SaveAsync(Argument.Is<Data.Budget>(b =>
           b.OwnerId == TestUserId
         ), Argument.IsAny<CancellationToken>()), Times.Once());
     };
@@ -103,10 +103,10 @@ namespace Platform8.Budgets.Tests
     [Fact]
     public void It_should_save_a_new_Category_to_the_Data_Repository() => should_save_a_new_Category_to_the_Data_Repository();
     It should_save_a_new_Category_to_the_Data_Repository = () => {
-        Sut.Verify<IAsyncRepository<BudgetsDataContext, Data.Category>>(p => p.SaveAsync(Argument.Is<Data.Category>(c =>           
+        Sut.Verify<IAsyncRepository<BudgetsDataContext>>(p => p.SaveAsync(Argument.Is<Data.Category>(c =>
           c.Name == Request.Name &&
           c.Allocation == Request.Allocation &&
-          c.Budget.Id.HasValue() 
+          c.Budget.Id.HasValue()
         ), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 

--- a/services/Budgets/Tests/Commands/AddCategory/Success.cs
+++ b/services/Budgets/Tests/Commands/AddCategory/Success.cs
@@ -56,11 +56,11 @@ namespace Platform8.Budgets.Tests
         }
       };
 
-      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext, Data.Budget>, Data.Budget>(r =>
+      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext>, Data.Budget>(r =>
          r.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Data.Budget, bool>>>(), Argument.IsAny<CancellationToken>()))
        .ReturnsAsync(testBudget);
 
-      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext, Data.Category>, Data.Category>(r => r.SaveAsync(Argument.IsAny<Data.Category>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<BudgetsDataContext>, Data.Category>(r => r.SaveAsync(Argument.IsAny<Data.Category>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Data.Category {
           Id = Guid.NewGuid(),
           Name = Request.Name,
@@ -85,13 +85,13 @@ namespace Platform8.Budgets.Tests
     public void It_should_get_the_Budget_the_user() => should_get_the_Budget_the_user();
     It should_get_the_Budget_the_user = () =>
     {
-      Sut.Verify<IAsyncRepository<BudgetsDataContext, Data.Budget>>(p => p.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Data.Budget, bool>>>(), Argument.IsAny<CancellationToken>()), Times.Once());
+      Sut.Verify<IAsyncRepository<BudgetsDataContext>>(p => p.FirstOrDefaultAsync(Argument.IsAny<Expression<Func<Data.Budget, bool>>>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 
     [Fact]
     public void It_should_save_a_new_Category_to_the_Data_Repository() => should_save_a_new_Category_to_the_Data_Repository();
     It should_save_a_new_Category_to_the_Data_Repository = () => {
-        Sut.Verify<IAsyncRepository<BudgetsDataContext, Data.Category>>(p => p.SaveAsync(Argument.IsAny<Data.Category>(), Argument.IsAny<CancellationToken>()), Times.Once());
+        Sut.Verify<IAsyncRepository<BudgetsDataContext>>(p => p.SaveAsync(Argument.IsAny<Data.Category>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
 
     [Fact]

--- a/services/Expenses/Api/Startup.cs
+++ b/services/Expenses/Api/Startup.cs
@@ -66,11 +66,11 @@ namespace Platform8.Expenses.Api
         )
         .AddContinuousMigrations<DataContext>()
 
-        .AddScoped(typeof(IAsyncRepository<,>), typeof(AsyncRepository<,>))
+        .AddScoped(typeof(IAsyncRepository<>), typeof(AsyncRepository<>))
         .AddMediatR(Aws.Commands.CommandsAssembly.Value)
         .AddMediatR(Expenses.Commands.CommandsAssembly.Value)
         .AddAutoMapper(Expenses.Commands.CommandsAssembly.Value);
-        
+
       services
         .AddAuthentication(options =>
         {
@@ -115,7 +115,7 @@ namespace Platform8.Expenses.Api
             ValidateAudience = false   // TODO: check this...
           };
         });
-      
+
       //
       // *****************************
 

--- a/services/Expenses/Commands/AddExpense.cs
+++ b/services/Expenses/Commands/AddExpense.cs
@@ -19,24 +19,24 @@ namespace Platform8.Expenses.Commands
     private readonly IMediator mediator;
     private readonly ILogger<AddExpenseHandler> logger;
     private readonly IMapper mapper;
-    private readonly IAsyncRepository<DataContext, Data.Expense> expenses;
+    private readonly IAsyncRepository<DataContext> repository;
 
     public AddExpenseHandler(
       IMediator mediator,
       IMapper mapper,
       ILogger<AddExpenseHandler> logger,
-      IAsyncRepository<DataContext, Data.Expense> expenses
+      IAsyncRepository<DataContext> repository
     )
     {
       this.mediator = mediator;
       this.mapper = mapper;
       this.logger = logger;
-      this.expenses = expenses;
+      this.repository = repository;
     }
 
     public async Task<AddExpenseResponse> Handle(AddExpenseRequest request, CancellationToken cancellationToken) {
 
-      var expense = await this.expenses.SaveAsync(new Data.Expense {
+      var expense = await this.repository.SaveAsync(new Data.Expense {
         OwnerId = request.OwnerId,
         Description = request.Description,
         Amount = request.Amount,
@@ -45,7 +45,7 @@ namespace Platform8.Expenses.Commands
         TransactionId = request.TransactionId
       });
 
-      await this.mediator.Publish(new PublishMessageRequest {        
+      await this.mediator.Publish(new PublishMessageRequest {
         Topic = "ExpenseAddedTopic",
         // To avoid dealing with mapping and setting naming option to camel case
         // just new up the message with camel casing.

--- a/services/User/Api/Startup.cs
+++ b/services/User/Api/Startup.cs
@@ -1,22 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.Text.Json;
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 
 using Amazon.CognitoIdentityProvider;
-using Amazon.Runtime;
 using Amazon.SimpleEmail;
 
 using ContinuousMigrations;
@@ -59,7 +54,7 @@ namespace Platform8.User.Api
                            x => x.MigrationsAssembly("User.Api")))
         .AddContinuousMigrations<UserDataContext>()
 
-        .AddScoped(typeof(IAsyncRepository<,>), typeof(AsyncRepository<,>))
+        .AddScoped(typeof(IAsyncRepository<>), typeof(AsyncRepository<>))
 
         .AddMediatR(Commands.CommandsAssembly.Value);
 

--- a/services/User/Commands/SaveUser.cs
+++ b/services/User/Commands/SaveUser.cs
@@ -13,9 +13,9 @@ namespace Platform8.User.Commands
   public class SaveUserHandler : IRequestHandler<SaveUserRequest, SaveUserResponse>
   {
 
-    private readonly IAsyncRepository<UserDataContext, Models.User> repository;
+    private readonly IAsyncRepository<UserDataContext> repository;
 
-    public SaveUserHandler(IAsyncRepository<UserDataContext, Models.User> repository)
+    public SaveUserHandler(IAsyncRepository<UserDataContext> repository)
     {
       this.repository = repository;
     }

--- a/services/User/Tests/Commands/SaveUser/Success.cs
+++ b/services/User/Tests/Commands/SaveUser/Success.cs
@@ -37,7 +37,7 @@ namespace Platform8.User.Tests {
         Email = "Bob@Jones.com"
       };
 
-      Sut.SetupAsync<IAsyncRepository<UserDataContext, Models.User>, Models.User>(r => r.SaveAsync(Argument.IsAny<Models.User>(), Argument.IsAny<CancellationToken>()))
+      Sut.SetupAsync<IAsyncRepository<UserDataContext>, Models.User>(r => r.SaveAsync(Argument.IsAny<Models.User>(), Argument.IsAny<CancellationToken>()))
         .ReturnsAsync(new Models.User {
           Id = Request.Id,
           FirstName = Request.FirstName,
@@ -61,7 +61,7 @@ namespace Platform8.User.Tests {
     [Fact]
     public void It_should_save_a_new_User_to_the_Data_Repository() => should_save_a_new_User_to_the_Data_Repository();
     It should_save_a_new_User_to_the_Data_Repository = () => {
-        Sut.Verify<IAsyncRepository<UserDataContext, Models.User>>(p => p.SaveAsync(Argument.IsAny<Models.User>(), Argument.IsAny<CancellationToken>()), Times.Once());
+        Sut.Verify<IAsyncRepository<UserDataContext>>(p => p.SaveAsync(Argument.IsAny<Models.User>(), Argument.IsAny<CancellationToken>()), Times.Once());
     };
   }
 


### PR DESCRIPTION
Moved TEntity from class to method level in order to make IRepository generic to a domain instead of a single domain entity.